### PR TITLE
fix: ormconfig pointing at js files instead of ts

### DIFF
--- a/ormconfig.json
+++ b/ormconfig.json
@@ -9,13 +9,13 @@
   "synchronize": true,
   "logging": false,
   "entities": [
-    "src/entity/*.js"
+    "src/entity/*.ts"
   ],
   "subscribers": [
-    "src/subscriber/*.js"
+    "src/subscriber/*.ts"
   ],
   "migrations": [
-    "src/migration/*.js"
+    "src/migration/*.ts"
   ],
   "cli": {
     "entitiesDir": "src/entity",


### PR DESCRIPTION
The `entities / subscribers / migrations` properties in the `ormconfig.json` file are pointing at `*.js` files, which was resulting in a `EntityMetadataNotFound:` error.

Changing to look for the correct file types fixes the error